### PR TITLE
Исправление ошибки в xml-ответе.

### DIFF
--- a/yandex_money/yandex_money.php
+++ b/yandex_money/yandex_money.php
@@ -331,6 +331,7 @@ function YMcheckPayment()
         }
         $answer = '<?xml version="1.0" encoding="UTF-8"?>
 			<'.$_POST['action'].'Response performedDatetime="'.date('c').'" code="'.$code.'" invoiceId="'.$_POST['invoiceId'].'" shopId="'.get_option('ym_ShopID').'" techMessage="'.$techMessage.'"/>';
+        ob_clean();
         die($answer);
     }
 }


### PR DESCRIPTION
В некоторых случаях в xml-ответе перед объявлением xml могут появится пробелы и переводы строки. Из-за этого xml-ответ не будет воспринят как xml и помечен как неверно сформированный. 
Функция ob_clean() очищает буфер вывода перед записью туда ответа, что позволяет избежать этой ошибки.