### PR TITLE
Disable annoying error_log calls.

### DIFF
--- a/yandex_money/yandex_money.php
+++ b/yandex_money/yandex_money.php
@@ -174,7 +174,6 @@ function register_my_setting() {
     register_setting( 'woocommerce-yamoney', 'ym_page_mpos');
     register_setting( 'woocommerce-yamoney', 'ym_success');
     register_setting( 'woocommerce-yamoney', 'ym_fail');
-    error_log("register_my_setting");
 }
 add_action('admin_menu', 'register_yandexMoney_submenu_page');
 add_action('update_option_ym_ShopID', 'after_update_setting');


### PR DESCRIPTION
Verbose logging must not be performed using error_log() call.